### PR TITLE
[BUG] - Fix adding PREreviews by pasting text from a Word document

### DIFF
--- a/client/components/editor/index.js
+++ b/client/components/editor/index.js
@@ -90,8 +90,18 @@ module.exports = class Editor extends Nanocomponent {
       this.quill.root.removeEventListener('click', clearPlaceholder);
     }
 
+    const rewriteContents = (ev) => {
+      // Set the same content over the existing one. This will trigger the text-change event
+      setTimeout(() => {
+        this.quill.setContents(this.quill.getContents());
+      });
+    }
+
     // Add the click event
     this.quill.root.addEventListener('click', clearPlaceholder);
+
+    // Add the paste event
+    this.quill.root.addEventListener('paste', rewriteContents);
 
     // focus cursor inside editor
     this.quill.focus()

--- a/client/stores/search.js
+++ b/client/stores/search.js
@@ -54,7 +54,10 @@ module.exports = function(state, emitter) {
         sortBy: state.sort.by,
         page: 1
       }
-      getLatest()
+      getLatest().then(() => {
+        state.getLatestDone = true;
+        emitter.emit('render')
+      })
     })
 
     emitter.on('preprint-search:update-sort', updateAfterSort)
@@ -86,7 +89,7 @@ module.exports = function(state, emitter) {
   }
 
   function getLatest() {
-    fetch('/data/preprints/latest', {
+    return fetch('/data/preprints/latest', {
       headers: {
         Accept: 'application/json'
       }

--- a/client/views/find.js
+++ b/client/views/find.js
@@ -6,6 +6,7 @@ var filterbox = require('../components/home/filterbox')
 var preprintlist = require('../components/home/preprintlist')
 var addButton = require('../components/home/add/button')
 var addModal = require('../components/home/add/modal')
+var loading = require('../components/utils/loading')
 var GRID = require('../grid')
 
 var TITLE = 'PREreview2 | find'
@@ -30,12 +31,17 @@ function view (state, emit) {
           ${filterbox(state, emit)}
         </div>
 
-        <div class="flex flex-column w-100 ">
-          ${preprintlist(state, emit)}
-          ${getResultString(state, emit)}
-          ${pagingbuttons(state, emit)}
-        </div>
-
+        ${state.getLatestDone
+          ? html`<div class="flex flex-column w-100 ">
+              ${preprintlist(state, emit)}
+              ${getResultString(state, emit)}
+              ${pagingbuttons(state, emit)}
+            </div>`
+          : html`<div class="flex flex-column mt6 w-100 h-100 bg-white justify-center items-center">
+              <p>loading</p>
+              ${loading()}
+            </div>`
+        }
       </div>
       
       ${addModal(state, emit)}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "0.1"
+version: "3"
 services:
   postgres:
     image: postgres:10.4

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,7 @@ var app = express()
 app.use(require('helmet')())
 
 // parse JSON body to req.body
-app.use(express.json())
+app.use(express.json({ limit: '50mb' }))
 
 // let's keep notes
 app.use(require('morgan')('combined'))

--- a/server/services/zenodo.js
+++ b/server/services/zenodo.js
@@ -36,7 +36,7 @@ const generateDOI = async prereviewData => {
       upload_type: 'publication',
       publication_type: 'article',
       title: prereviewData.title,
-      description: prereviewData.content,
+      description: prereviewData.content || "No content.",
       creators: [{
         name: prereviewData.authorName,
         orcid: prereviewData.authorOrcid


### PR DESCRIPTION
**Prerequisites:**
1. Start creating a new PREreview
2. Paste a rich-text content in the Quill editor (E.g. text from a Word document)
3. Click `Publish`

**Issue description:**
1. The publishing process hangs.
2. The page shows an infinite loading screen and the publishing never finishes.

**Reason:**
1. Pasting in the Quill editor is not registered as a `text-change` event. The content that should have been passed to the server was not sent, since Quill didn't detect a change in the text body.

**The fix:**
1. Force a Quill update on `paste`. On  clipboard `paste`, trigger the `text-change` event so that the content gets updated and sent properly.
2. Side-fix: Increase the request payload size to 50mb to accept larger PREreviews


